### PR TITLE
Expand download command to allow downloading the images locally

### DIFF
--- a/paprika_recipes/commands/download_recipes.py
+++ b/paprika_recipes/commands/download_recipes.py
@@ -16,7 +16,12 @@ class Command(RemoteCommand):
     @classmethod
     def add_arguments(cls, parser: argparse.ArgumentParser, config: ConfigDict) -> None:
         parser.add_argument("export_path", type=Path)
-        parser.add_argument("--download_images", default=False, type=bool, help="Allows to download every image attached to the recipes")
+        parser.add_argument(
+            "--download_images",
+            default=False,
+            type=bool,
+            help="Allows to download every image attached to the recipes",
+        )
 
     def handle(self) -> None:
         remote = self.get_remote()

--- a/paprika_recipes/commands/download_recipes.py
+++ b/paprika_recipes/commands/download_recipes.py
@@ -16,6 +16,7 @@ class Command(RemoteCommand):
     @classmethod
     def add_arguments(cls, parser: argparse.ArgumentParser, config: ConfigDict) -> None:
         parser.add_argument("export_path", type=Path)
+        parser.add_argument("--download_images", default=False, type=bool, help="Allows to download every image attached to the recipes")
 
     def handle(self) -> None:
         remote = self.get_remote()
@@ -25,6 +26,8 @@ class Command(RemoteCommand):
         for recipe in track(
             remote, total=remote.count(), description="Downloading Recipes"
         ):
+            if self.options.download_images:
+                remote.download_image(recipe)
             with open(
                 self.options.export_path / Path(f"{recipe.name}.paprikarecipe.yaml"),
                 "w",

--- a/paprika_recipes/commands/download_recipes.py
+++ b/paprika_recipes/commands/download_recipes.py
@@ -1,5 +1,7 @@
 import argparse
 from pathlib import Path
+import os
+import urllib
 
 from rich.progress import track
 
@@ -17,10 +19,10 @@ class Command(RemoteCommand):
     def add_arguments(cls, parser: argparse.ArgumentParser, config: ConfigDict) -> None:
         parser.add_argument("export_path", type=Path)
         parser.add_argument(
-            "--download_images",
+            "--download-images",
             default=False,
             type=bool,
-            help="Allows to download every image attached to the recipes",
+            help="Downloads images attached to the recipes",
         )
 
     def handle(self) -> None:
@@ -32,7 +34,22 @@ class Command(RemoteCommand):
             remote, total=remote.count(), description="Downloading Recipes"
         ):
             if self.options.download_images:
-                remote.download_image(recipe)
+                images_path = self.options.export_path / "images"
+                images_path.mkdir(parents=True, exist_ok=True)
+
+                image = remote.fetch_recipe_image(recipe)
+                if image is not None:
+                    file_extension = os.path.splitext(recipe.photo)[1]
+                    destination_path = images_path / f"{recipe.uid}{file_extension}"
+
+                    file = open(destination_path, "wb")
+                    file.write(image)
+                    file.close()
+
+                    recipe.local_image_url = destination_path.relative_to(
+                        self.options.export_path
+                    ).as_posix()
+
             with open(
                 self.options.export_path / Path(f"{recipe.name}.paprikarecipe.yaml"),
                 "w",

--- a/paprika_recipes/constants.py
+++ b/paprika_recipes/constants.py
@@ -1,2 +1,1 @@
 APP_NAME = "paprika-recipes"
-

--- a/paprika_recipes/recipe.py
+++ b/paprika_recipes/recipe.py
@@ -28,6 +28,7 @@ class BaseRecipe:
         ).hexdigest()
     )
     image_url: str = ""
+    local_image_url: str = ""
     ingredients: str = ""
     name: str = ""
     notes: str = ""
@@ -59,7 +60,9 @@ class BaseRecipe:
         return gzip.compress(self.as_json().encode("utf-8"))
 
     def as_json(self):
-        return json.dumps(self.as_dict())
+        as_dict = self.as_dict()
+        del as_dict["local_image_url"]
+        return json.dumps(as_dict)
 
     def as_dict(self):
         return asdict(self)

--- a/paprika_recipes/remote.py
+++ b/paprika_recipes/remote.py
@@ -3,6 +3,7 @@ from typing import Dict, Iterable, Iterator, List, Optional
 
 import requests
 import os
+import urllib
 
 from .exceptions import PaprikaError, RequestError
 from .recipe import BaseRecipe
@@ -76,29 +77,12 @@ class Remote(RecipeManager):
     def count(self) -> int:
         return len(self._get_remote_recipe_identifiers())
 
-    def download_image(self, recipe: RemoteRecipe):
-
+    def fetch_recipe_image(self, recipe: RemoteRecipe):
         if recipe.image_url:
             result = requests.request("GET", recipe.image_url)
             result.raise_for_status()
 
-            if not os.path.exists("images"):
-                os.mkdir("images")
-
-            url = recipe.image_url
-
-            # Remove query parameters from the URL.
-            if url.find("?") != -1:
-                url = url[: url.find("?")]
-
-            filename, file_extension = os.path.splitext(url)
-            destination_filename = f"images/{recipe.uid}{file_extension}"
-
-            file = open(destination_filename, "wb")
-            file.write(result.content)
-            file.close()
-
-            recipe.image_url = destination_filename
+            return result.content
 
     def upload_recipe(self, recipe: RemoteRecipe) -> RemoteRecipe:
         recipe.update_hash()

--- a/paprika_recipes/remote.py
+++ b/paprika_recipes/remote.py
@@ -79,17 +79,17 @@ class Remote(RecipeManager):
     def download_image(self, recipe: RemoteRecipe):
 
         if recipe.image_url:
-            result = requests.request('GET', recipe.image_url)
+            result = requests.request("GET", recipe.image_url)
             result.raise_for_status()
 
-            if not os.path.exists('images'):
-                os.mkdir('images')
+            if not os.path.exists("images"):
+                os.mkdir("images")
 
             url = recipe.image_url
 
             # Remove query parameters from the URL.
-            if url.find('?') != -1:
-                url = url[:url.find('?')]
+            if url.find("?") != -1:
+                url = url[: url.find("?")]
 
             filename, file_extension = os.path.splitext(url)
             destination_filename = f"images/{recipe.uid}{file_extension}"


### PR DESCRIPTION
Solves https://github.com/coddingtonbear/paprika-recipes/issues/1

# Description

Allows downloading the image

# Approach

- Adds a boolean option to download files ... Maybe it would be better to use a file path instead?
- Downloads the files into the /images folder. In order to have sane filenames it generates a filename based upon the UUID. Does that make sense?

# "Screenshot"

```
ls images/
0A828C97-3089-40F6-8660-2ACFAAB9AEDD-2548-00001632292797BD.jpg
0C661AA4-1C04-439C-B800-5D9458FE9D04-12045-00000553DB84C76A.jpg
05CC55AC-E3C8-4E49-BA94-00E262DB4E5D-33454-0000137C0368DABA.jpg
1B6D3BBC-E87A-402C-BFFB-C487B0F12441-1558-0000145CB562A12D.jpg
1BFF70A1-7C54-4054-B620-B54CD700C21C-1558-00000440459454A4.jpg
2A4D5E88-8828-4BA9-944F-80E60E6BF9B0-1920-0000011E9C2B219C.jpg
2F893658-5BF5-4C42-89FC-ED527E693C39-1558-0000047A223F9B3D.jpg
3B478F5E-818A-4FF6-98F0-CB212FD167CD-1558-0000148455CAD89A.jpg
```