### PR TITLE
Encode "/" in filenames

### DIFF
--- a/paprika_recipes/commands/download_recipes.py
+++ b/paprika_recipes/commands/download_recipes.py
@@ -26,7 +26,7 @@ class Command(RemoteCommand):
             remote, total=remote.count(), description="Downloading Recipes"
         ):
             with open(
-                self.options.export_path / Path(f"{recipe.name}.paprikarecipe.yaml"),
+                self.options.export_path / Path(f"{recipe.safe_name}.paprikarecipe.yaml"),
                 "w",
             ) as outf:
                 dump_recipe_yaml(recipe, outf)

--- a/paprika_recipes/recipe.py
+++ b/paprika_recipes/recipe.py
@@ -74,6 +74,10 @@ class BaseRecipe:
     def update_hash(self):
         self.hash = self.calculate_hash()
 
+    @property
+    def safe_name(self):
+        return self.name.replace("/", "%2F")
+
     def __str__(self):
         return self.name
 


### PR DESCRIPTION
Replace "/" in recipe names with "%2F". Without this change a recipe whose
name contains "/" cannot be saved to the filesystem.

Closes #6
