### PR TITLE
Add explicit UTF-8 Encoding when opening files in write mode.

### DIFF
--- a/paprika_recipes/commands/download_recipes.py
+++ b/paprika_recipes/commands/download_recipes.py
@@ -28,5 +28,6 @@ class Command(RemoteCommand):
             with open(
                 self.options.export_path / Path(f"{recipe.name}.paprikarecipe.yaml"),
                 "w",
+                encoding='utf-8'
             ) as outf:
                 dump_recipe_yaml(recipe, outf)

--- a/paprika_recipes/commands/extract_archive.py
+++ b/paprika_recipes/commands/extract_archive.py
@@ -27,6 +27,6 @@ class Command(BaseCommand):
                 with open(
                     self.options.export_path
                     / Path(f"{recipe.name}.paprikarecipe.yaml"),
-                    "w",
+                    "w", encoding='utf-8'
                 ) as outf:
                     dump_recipe_yaml(recipe, outf)


### PR DESCRIPTION
See [Issue 10](https://github.com/coddingtonbear/paprika-recipes/issues/10) for some context on the issue.

I was able to resolve this by just explicitly opening each file with. `encoding='utf-8'`, since it was failing to read some fraction unicode characters (e.g., \u2159, \u2153).

Please let me know if there are other locations I should add the encoding to as part of this change. These were the two relevant to me, I wasn't sure if there are others.